### PR TITLE
Remove support for v4 + update documentation to use Go based CLI

### DIFF
--- a/docs-content/index.html.md.erb
+++ b/docs-content/index.html.md.erb
@@ -179,11 +179,6 @@ $ openssl s_client -showcerts -servername [CONJUR_DNS_NAME] \
        $ cf create-service cyberark-conjur community my-service-instance-name
     ```
 
-+ **(Conjur EE v4.x only) Conjur Host Factory**
-
-    The Service Broker requires a Conjur host factory to use when adding host identities. The examples in [Recommendations](#recommendations) include host factory definitions. If a host factory is not properly defined, a health check near the end of tile installation will report the condition, and the tile installation will fail.
-
-
 ## <a id="recommendations"></a>Recommendations
 
 ### Create a Dedicated Conjur Policy for VMware Tanzu
@@ -211,13 +206,11 @@ A dedicated Conjur policy for VMware Tanzu supports least privilege principles i
 * The secrets, host identities, and access control policies for your VMware Tanzu-deployed applications are isolated from other resources stored in Conjur.
 * Conjur access privileges required by the Service Broker, DevOps teams, and your applications can be limited in scope to the dedicated Conjur policy for VMware Tanzu.
 * You can give a limited set of Conjur users access to the dedicated Conjur policy for VMware Tanzu, with even finer-grained permissions possible within the VMware Tanzu policy itself.
-* For Conjur Enterprise (v4), you can define the host factory layer in the dedicated Conjur policy for VMware Tanzu, rather than in the root policy.
 
 When creating the dedicated Conjur policy for VMware Tanzu, consider the following:
 
 * The Service Broker requires `create` and `update` privileges on the policy to add and remove host identities. Members of the group that owns the policy have those privileges.
 * VMware Tanzu DevOps personnel need access to Conjur to declare application secrets and grant privileges to the applications to access those secrets.
-* For Conjur Enterprise (v4), a host factory is required. Both the ID of the layer and the host factory must use the syntax `[policy-id]-apps`, where `apps` is a constant. For example, `pcf/production-apps` is used in the policy example shown below where the dedicated policy for VMware Tanzu is called `pcf/production`.
 
 To create a dedicated Conjur policy for VMware Tanzu, do the following:
 
@@ -251,55 +244,17 @@ Create a policy using the following example as a guide. Save the policy as a YAM
     id: production                   # Multiple VMware Tanzu Foundations may be identified using
                                      # a sub-policy branch, e.g. "production".
     owner: !group /pcf-admin-group   # Owners have complete privileges on the policy
-
-    # The policy body, layer, and host factory
-    # are required for Conjur EE v4:
-    body:
-
-    # Layer name and host-factory name must be [policy-id]-apps
-    - !layer pcf/production-apps
-
-    - !host-factory
-      id: pcf/production-apps
-      layers: [ !layer pcf/production-apps ]
 ```
 
 This policy file creates a `host/pcf-service-broker` host that can be used as the `CONJUR_AUTHN_LOGIN` role
 in the tile configuration. The `pcf-service-broker` host is a member of the `pcf-admin-group` group, which
 owns the `pcf/production` policy, so it has `create` and `update` privileges on that policy as required.
 
-The VMware Tanzu policy has a `pcf/production-apps` layer and corresponding host factory. If using Conjur v4, application
-hosts will be added to the `pcf/production-apps` layer via the `pcf-apps` host factory when the application is
-bound to a Conjur service instance.
-
 #### Step 2
 
 Load the policy into Conjur as follows (in this example, we are loading it into the root policy):
 
-**For Conjur Enterprise v4:**
-
-<pre class='term'>$ conjur policy load --as-group security_admin your-pcf-policy-file.yml</pre>
-
-> **NOTE:** You may have to first install the `policy` plugin for the Conjur CLI. If you receive
-> this message when loading the policy:
->
-> ```
-> $ conjur policy load ...
-> error: Unknown command 'policy'
-> ```
->
-> Then you may install the `policy` plugin using the command:
->
-> ```
-> $ conjur plugin install policy
-> Successfully installed conjur-asset-policy-0.13.0
-> 1 gem installed
-> ```
-
-
-**For Conjur Open Source and Conjur Enterprise v5:**
-
-<pre class='term'>$ conjur policy load root your-pcf-policy-file.yml</pre>
+<pre class='term'>$ conjur policy load -b root -f your-pcf-policy-file.yml</pre>
 
 Loading this policy the first time will output the API key for the `pcf-service-broker` host. Save
 this key to use when configuring the VMware Tanzu tile below.
@@ -316,7 +271,7 @@ In the CyberArk Conjur Service Broker for VMware Tanzu tile configuration:
   needs to be permitted to read its own annotations.
 
 * For **Conjur API Key**, use that host's API key. The admin who created the role can retrieve the value with this command:
-  <pre class='term'>$ conjur host rotate_api_key -h pcf-service-broker</pre>
+  <pre class='term'>$ conjur host rotate-api-key -i pcf-service-broker</pre>
 
 
 ### Using the Default Root Policy
@@ -327,15 +282,6 @@ If you decide to leave the **VMware Tanzu Conjur Policy Namespace** blank in the
 * The Conjur host identity that you provide on tile installation must have `create` and `update` privileges on the root policy, which means that it will be privileged to edit _any policy in your Conjur installation_.
 * The Service Broker will add host identities for your VMware Tanzu applications to the root policy.
 * The VMware Tanzu DevOps teams will be altering policy files in the root policy.
-* For integration with Conjur v4, a Host Factory named `apps` is required. Add the following layer declaration to the root policy:
-
-    ```
-    - !layer apps
-
-    - !host-factory
-    id: apps
-    layers: [ !layer apps ]
-    ```
 
 ## <a id="limitations"></a>Limitations
 

--- a/docs-content/using/_deploy-app.html.md.erb
+++ b/docs-content/using/_deploy-app.html.md.erb
@@ -47,32 +47,15 @@ If your application uses another method to access secrets, such as Conjur API ca
 
 5. If you created a `my-app.yml` policy file, load it into Conjur under the dedicated Conjur policy for PCF. For example, if your dedicated Conjur policy for PCF is called `pcf`:
 
-    **For Enterprise Conjur v4:**
+    The recommendation is to store the policy for resources and secrets outside of the service broker managed
+    policy branch.
 
-      Add `!include my-app.yml` to the body of the `pcf` policy (defined in `pcf.yml` in the example below) and reload the policy as follows:
+    To accomplish this with `my-app.yml`, first create a policy
+    branch, for example `apps`, and then load the app policy to that branch:
 
-      ```
-      $ conjur policy load --as-group security_admin pcf.yml
-      ```
-
-      If `pcf.yml` contains only the `pcf` policy, and if we have set that policy so that it is owned by the `pcf-admin-group` group, you could also reload by calling:
-
-      ```
-      $ conjur policy load --as-group pcf-admin-group pcf.yml
-      ```
-
-    **For Open Source Conjur and Enterprise Conjur v5:**
-
-      For Conjur Enterprise v5 and Open Source, the recommendation is to store
-      the policy for resources and secrets outside of the service broker managed
-      policy branch.
-
-      To accomplish this with `my-app.yml`, first create a policy
-      branch, for example `apps`, and then load the app policy to that branch:
-
-      ```
-      $ conjur policy load apps my-app.yml
-      ```
+    ```
+    $ conjur policy load -b apps -f my-app.yml
+    ```
 
 ##### <a id="secrets.yml"></a>Example: secrets.yml
 
@@ -124,7 +107,7 @@ The following example shows a Conjur application policy declaring two secrets as
 Values can be stored in these variables using the Conjur CLI, for example:
 
 ```
-$ conjur variable values add "my-app/db/username" "My username value"
+$ conjur variable set -i "my-app/db/username" -v "My username value"
 Value added
 ```
 
@@ -194,7 +177,7 @@ may be used to access variables in Conjur policy. For example:
 This can then be loaded into conjur with:
 
 ```
-conjur policy load root org-space-entitlements.yml
+conjur policy load -b root -f org-space-entitlements.yml
 ```
 
 #### <a id="edit-manifest"></a> Step 4: Edit Application Manifest

--- a/docs-content/using/_entitle-app.html.md.erb
+++ b/docs-content/using/_entitle-app.html.md.erb
@@ -38,24 +38,6 @@ may still be used to permit specific applications to access Conjur secrets.
 2. Update policy to grant read and execute privileges to the new host ID on a set of secrets.
    For example, the following policy adds the new host to the existing secrets-users group. You can save these lines in a separate file, such as `app-entitlements.yml`.
 
-   **For Conjur Enterprise v4:**
-
-   ```
-    # app-entitlements.yml
-
-   - !grant
-     role: !group my-app/secrets-users
-     member: !host /pcf/production/0299a19d-7de4-4e98-89f6-372ac7c0521f
-   ```
-
-   Load the policy with:
-
-   ```
-   conjur policy load --as-group security_admin app-entitlements.yml
-   ```
-
-   **For Conjur Open Source and Conjur Enterprise v5:**
-
    The application host will be loaded into the Org and Space policy hierarchy:
 
    ```
@@ -67,13 +49,11 @@ may still be used to permit specific applications to access Conjur secrets.
    Load the policy with:
 
    ```
-   conjur policy load root app-entitlements.yml
+   conjur policy load -b root -f ./app-entitlements.yml
    ```
 
 3. Load the policy change. The following command loads the grant in `entitlements.yml` into the `apps` Conjur policy:
-   <pre class='term'>$ conjur policy load apps entitlements.yml</pre>
-
-   In Enterprise Conjur (v4), you could also choose to use an `!include` statement in the existing PCF Policy.
+   <pre class='term'>$ conjur policy load -b apps -f ./entitlements.yml</pre>
 
 ####<a id="restage"></a>Step 3: Restage the Application
 

--- a/docs-content/using/_rotate-credentials.html.md.erb
+++ b/docs-content/using/_rotate-credentials.html.md.erb
@@ -20,20 +20,20 @@ requires coordinating the host credential update with all apps in a space.
 1. Rotate the Space Host API key using the Conjur CLI. This returns the new API key for the host:
 
     ```sh
-    conjur host rotate_api_key --host <cf policy root>/<org-guid>/<space-guid>
+    conjur host rotate-api-key -i <cf policy root>/<org-guid>/<space-guid>
 
     # for example
-    $ conjur host rotate_api_key --host cf/prod/6b40649e-331b-424d-afa0-6d569f016f51/72a928f6-bf7c-4732-a195-896f67bd1133
+    $ conjur host rotate-api-key -i cf/prod/6b40649e-331b-424d-afa0-6d569f016f51/72a928f6-bf7c-4732-a195-896f67bd1133
     1p9c5443sy1bg93ek2e062wsnmvy3p9k9j83nq841sj1sp2vasze1r
     ```
 
 2. Update the Space API key secret in Conjur:
 
     ```
-    conjur variable values add "<cf policy root>/<org-guid>/<space-guid>/space-host-api-key" "<api-key-value>"
+    conjur variable set -i "<cf policy root>/<org-guid>/<space-guid>/space-host-api-key" -v "<api-key-value>"
 
     # For example:
-    conjur variable values add "cf/prod/6b40649e-331b-424d-afa0-6d569f016f51/72a928f6-bf7c-4732-a195-896f67bd1133/space-host-api-key" "1p9c5443sy1bg93ek2e062wsnmvy3p9k9j83nq841sj1sp2vasze1r"
+    conjur variable set -i "cf/prod/6b40649e-331b-424d-afa0-6d569f016f51/72a928f6-bf7c-4732-a195-896f67bd1133/space-host-api-key" -v "1p9c5443sy1bg93ek2e062wsnmvy3p9k9j83nq841sj1sp2vasze1r"
     ```
 
 3. Re-bind each application in the space to Conjur


### PR DESCRIPTION
1. Conjur v4 has long been sunset
2. There's a brand new CLI which comes with some changes to the interface

We're just updating the documentation to reflect the current state of things