### PR TITLE
Upgrade ruby from 2.4-stretch to 3.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:2.4-stretch as pivotal-docs-site
+FROM ruby:3.1 as pivotal-docs-site
 
 RUN mkdir -p /docs/docs-book
 


### PR DESCRIPTION
This pull request updates Ruby from 2.4-stretch to 3.1 in the base image used to run the website locally in Docker.